### PR TITLE
Test setup updates.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-htmlcov
-.tox
 .coverage
 coverage.xml
 .cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
+dist: xenial
 language: python
 python:
 - '2.7'
 services:
 - docker
-- redis
 install:
 - pip install --upgrade pip setuptools wheel
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,8 @@ services:
 install:
 - pip install --upgrade pip setuptools wheel
 script:
-- docker-compose build
-- docker-compose up --no-start
-- docker-compose start postgres
-- docker-compose run --rm server sh -c "/redash-stmo/bin/wait-for-it.sh postgres:5432 -- python manage.py database create_tables"
-- docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests;"
 - export CI_ENV=`bash <(curl -s https://codecov.io/env)`
-- docker-compose run $CI_ENV server tests
+- make test
 deploy:
   provider: pypi
   user: emtwo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 FROM mozilla/redash:latest
 
-COPY . /redash-stmo
-
 ENV PYTHONUNBUFFERED=0 \
-	PYTHONPATH=/app/ \
+	PYTHONPATH=/redash-stmo:/redash-stmo/src:/app \
 	REDASH_LOG_LEVEL="INFO" \
 	REDASH_REDIS_URL=redis://redis:6379/0 \
 	REDASH_DATABASE_URL=postgresql://postgres@postgres/postgres
 
 USER root
-RUN pip uninstall -y redash-stmo && pip install -e /redash-stmo
+RUN pip uninstall -y redash-stmo
 USER redash
 
 ENTRYPOINT ["/redash-stmo/bin/docker-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redash/redash:latest
+FROM mozilla/redash:latest
 
 COPY . /redash-stmo
 
@@ -9,7 +9,7 @@ ENV PYTHONUNBUFFERED=0 \
 	REDASH_DATABASE_URL=postgresql://postgres@postgres/postgres
 
 USER root
-RUN pip install -e /redash-stmo
+RUN pip uninstall -y redash-stmo && pip install -e /redash-stmo
 USER redash
 
 ENTRYPOINT ["/redash-stmo/bin/docker-entrypoint"]

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,8 @@ release: build
 
 test:
 	docker-compose build --pull
-	docker-compose up --no-start
-	docker-compose start postgres
-	docker-compose run --rm server sh -c "/redash-stmo/bin/wait-for-it.sh postgres:5432 -- python manage.py database create_tables"
+	docker-compose up -d
+	docker-compose run --rm server sh -c "/redash-stmo/bin/wait-for-it.sh postgres:5432 -- python /app/manage.py database create_tables"
 	docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests;" || echo "Test database exists already."
 	docker-compose run --rm $(CI_ENV) server tests
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean release sdist wheel
+.PHONY: build clean release sdist test wheel
 
 clean:
 	rm -rf build/ dist/
@@ -13,3 +13,12 @@ build: clean sdist wheel
 
 release: build
 	twine upload -s dist/*
+
+test:
+	docker-compose build --pull
+	docker-compose up --no-start
+	docker-compose start postgres
+	docker-compose run --rm server sh -c "/redash-stmo/bin/wait-for-it.sh postgres:5432 -- python manage.py database create_tables"
+	docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests;" || echo "Test database exists already."
+	docker-compose run --rm $(CI_ENV) server tests
+	docker-compose down

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,6 +2,7 @@
 set -e
 
 server() {
+  pip install --user -e /redash-stmo
   exec /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app
 }
 
@@ -10,6 +11,8 @@ create_db() {
 }
 
 tests() {
+  pip install --user /redash-stmo
+  pip install --user pytest mock pytest-cov pytest-flake8
   export REDASH_DATABASE_URL="postgresql://postgres@postgres/tests"
 
   if [ $# -eq 0 ]; then
@@ -23,6 +26,8 @@ tests() {
     bash <(curl -s https://codecov.io/bash) -s /tmp
   fi
 }
+
+# always install inside the running container
 
 case "$1" in
   tests)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       QUEUES: "queries,scheduled_queries,celery"
       WORKERS_COUNT: 2
+      REDASH_REDIS_URL: "redis://redis:6379/0"
   redis:
     image: redis:3.0-alpine
     restart: unless-stopped

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 norecursedirs = .git .*
-addopts = -rsxX --showlocals --tb=native --cov=redash_stmo --cov-report xml --cov-report term --cov-report html --cov-config .coveragerc --cov-config /redash-stmo/.coveragerc
-python_paths = .
+addopts = --flake8 -rsxX --showlocals --tb=native --cov=redash_stmo --cov-report xml --cov-report term --cov-config .coveragerc --cov-config /redash-stmo/.coveragerc

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=1
+
+[flake8]
+ignore=E501,E127,E128,E124,W503

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
     license='MPL 2.0',
     entry_points={
         'redash.extensions': [
-            'dockerflow = redash_stmo.dockerflow:dockerflow',
-            'datasource_health = redash_stmo.data_sources.health:health',
-            'datasource_link = redash_stmo.data_sources.link:link',
-            'datasource_version = redash_stmo.data_sources.version:version',
+            'dockerflow = redash_stmo.dockerflow:extension',
+            'datasource_health = redash_stmo.data_sources.health:extension',
+            'datasource_link = redash_stmo.data_sources.link:extension',
+            'datasource_version = redash_stmo.data_sources.version:extension',
         ],
     },
     classifiers=[

--- a/src/redash_stmo/data_sources/health.py
+++ b/src/redash_stmo/data_sources/health.py
@@ -66,7 +66,7 @@ def update_health_status():
         except NotImplementedError:
             logger.info(u"Unable to compute health status without test query for %s", data_source.name)
             continue
-        except Exception as e:
+        except Exception:
             logger.warning(u"Failed health check for the data source: %s", data_source.name, exc_info=1)
             statsd_client.incr('update_health_status.error')
             logger.info(u"task=update_health_status state=error ds_id=%s runtime=%.2f", data_source.id, time.time() - start_time)

--- a/src/redash_stmo/data_sources/health.py
+++ b/src/redash_stmo/data_sources/health.py
@@ -105,7 +105,7 @@ def stmo_status_api():
     return jsonify(status)
 
 
-def health(app=None):
+def extension(app=None):
     """A Redash extension to add datasource health status reporting."""
 
     # Override the default status API view with our extended view

--- a/src/redash_stmo/data_sources/link/__init__.py
+++ b/src/redash_stmo/data_sources/link/__init__.py
@@ -53,7 +53,8 @@ class DataSourceLinkResource(BaseResource):
         else:
             return {"message": result, "ok": True}
 
-def link(app=None):
+
+def extension(app=None):
     for runner_type, runner_class in query_runners.items():
         if runner_type not in DATASOURCE_URLS:
             continue

--- a/src/redash_stmo/data_sources/version/__init__.py
+++ b/src/redash_stmo/data_sources/version/__init__.py
@@ -62,5 +62,5 @@ def get_data_source_version(query_runner):
     return version
 
 
-def version(app=None):
+def extension(app=None):
     add_resource(app, DataSourceVersionResource, '/api/data_sources/<data_source_id>/version')

--- a/src/redash_stmo/dockerflow.py
+++ b/src/redash_stmo/dockerflow.py
@@ -11,7 +11,7 @@ from redash.models import db
 logger = logging.getLogger(__name__)
 
 
-def dockerflow(app):
+def extension(app):
     logger.info('Loading Redash Extension for Dockerflow')
     dockerflow = Dockerflow(app, db=db, migrate=migrate, redis=redis_connection)
     logger.info('Loaded Redash Extension for Dockerflow')

--- a/tests/test_datasource_link.py
+++ b/tests/test_datasource_link.py
@@ -1,7 +1,6 @@
 import mock
 
 from tests import BaseTestCase
-from redash_stmo.data_sources.link import link
 
 
 class TestDatasourceLink(BaseTestCase):
@@ -11,7 +10,6 @@ class TestDatasourceLink(BaseTestCase):
         super(TestDatasourceLink, self).setUp()
         self.patched_query_runners = self._setup_mock('redash_stmo.data_sources.link.query_runners')
         self.patched_query_runners.return_value = {}
-        link(self.app)
 
     def _setup_mock(self, function_to_patch):
         patcher = mock.patch(function_to_patch)

--- a/tests/test_datasource_version.py
+++ b/tests/test_datasource_version.py
@@ -24,7 +24,7 @@ class TestDatasourceVersion(BaseTestCase):
         self.patched_runner_type.return_value = runner_type
         self.patched_run_query.return_value = (json.dumps({
             "rows":
-                [{ "version": version_string.format(version=expected_version) }]
+                [{"version": version_string.format(version=expected_version)}]
         }), None)
         rv = self.make_request('get', '/api/data_sources/{}/version'.format(self.data_source.id), user=self.admin)
         self.assertEqual(200, rv.status_code)
@@ -58,7 +58,7 @@ class TestDatasourceVersion(BaseTestCase):
         self.patched_runner_type.return_value = "pg"
         self.patched_run_query.return_value = (json.dumps({
             "rows":
-                [{ "bad_json": "foo" }]
+                [{"bad_json": "foo"}]
         }), None)
         rv = self.make_request('get', '/api/data_sources/{}/version'.format(self.data_source.id), user=self.admin)
         self.assertEqual(200, rv.status_code)

--- a/tests/test_datasource_version.py
+++ b/tests/test_datasource_version.py
@@ -3,8 +3,6 @@ import mock
 
 from tests import BaseTestCase
 
-from redash_stmo.data_sources.version import version
-
 
 class TestDatasourceVersion(BaseTestCase):
     EXPECTED_DOC_URL = "www.example.com"
@@ -15,7 +13,6 @@ class TestDatasourceVersion(BaseTestCase):
         self.data_source = self.factory.create_data_source()
         self.patched_run_query = self._setup_mock('redash.query_runner.pg.PostgreSQL.run_query')
         self.patched_runner_type = self._setup_mock('redash.query_runner.pg.PostgreSQL.type')
-        version(self.app)
 
     def _setup_mock(self, function_to_patch):
         patcher = mock.patch(function_to_patch)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,7 +5,7 @@ import mock
 from tests import BaseTestCase
 
 from redash import redis_connection
-from redash_stmo.data_sources.health import store_health_status, update_health_status, health
+from redash_stmo.data_sources.health import store_health_status, update_health_status
 
 
 class TestHealthStatus(BaseTestCase):
@@ -16,8 +16,6 @@ class TestHealthStatus(BaseTestCase):
 
         self.patched_run_query.return_value = ("some_data", None)
         os.environ["REDASH_CUSTOM_HEALTH_QUERIES_1"] = ""
-
-        health(self.app)
 
     def _setup_mock(self, function_to_patch):
         patcher = mock.patch(function_to_patch)


### PR DESCRIPTION
- Uses mozilla/redash base image for better parity.
- Renames extension functions to one conventional name "extension".
- Removes uneeded manual initialization of extensions by installing
  package in Docker container.
- Moves test comands into make task "test. -> run `make test` locally.
- Use Xenial on Travis for newer Docker.
- Use Docker redis on Travis instead of Travis service.
- Add running flake8.
- Minor code fixes.