### PR TITLE
Use Standard SQL docs for BigQuery documentation

### DIFF
--- a/src/redash_stmo/data_sources/link/extension.py
+++ b/src/redash_stmo/data_sources/link/extension.py
@@ -6,7 +6,7 @@ from six import text_type
 
 
 DATASOURCE_URLS = {
-    "bigquery": "https://cloud.google.com/bigquery/docs/reference/legacy-sql",
+    "bigquery": "https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators",
     "Cassandra": "http://cassandra.apache.org/doc/latest/cql/index.html",
     "dynamodb_sql": "https://dql.readthedocs.io/en/latest/",
     "baseelasticsearch": "https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html",


### PR DESCRIPTION
This fixes "BigQuery documentation" URL which currently sends users to legacy docs.