### PR TITLE
Fix docker from scratch setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 services:
   server:
     build: .
-    command: dev_server
+    command: /app/bin/docker-entrypoint dev_server
     depends_on:
       - postgres
       - redis
@@ -29,11 +29,11 @@ services:
       REDASH_MAIL_SERVER: email
   scheduler:
     build: .
-    command: dev_scheduler
+    command: /app/bin/docker-entrypoint dev_scheduler
     volumes:
       - type: bind
         source: .
-        target: /app
+        target: /extension
     depends_on:
       - server
     environment:
@@ -42,11 +42,11 @@ services:
       REDASH_MAIL_SERVER: email
   worker:
     build: .
-    command: dev_worker
+    command: /app/bin/docker-entrypoint dev_worker
     volumes:
       - type: bind
         source: .
-        target: /app
+        target: /extension
     depends_on:
       - server
     environment:

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
             "pytest-cov",
             "pytest-flake8<1.0.1",
         ],
-        "dev": ["watchdog"],
+        "dev": ["watchdog[watchmedo]"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
             "mock",
             "pytest",
             "pytest-cov",
-            "pytest-flake8<1.0.1",
+            "pytest-flake8>=1.0.5",
         ],
         "dev": ["watchdog[watchmedo]"],
     },


### PR DESCRIPTION
I tried to run the setup steps in the README from a brand new clone of the repo and ran into a few issues – these updates fixed the issues for me

- The redash core code in /app was being clobbered by the docker-compose volume binds into /app – I moved those to `/extension`
- The dev_<process> commands don't exist in this repo's entrypoint script, so I moved the call to the redash core entrypoint script
- `watchmedo` was moved to an extra in `watchdog`, so the dependency declaration had to be changed